### PR TITLE
template as function

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -23,7 +23,7 @@ var generate = function(req, res, next) {
         if(!multiRequest.isMultiRequest(path)) {
 
             var isCollection = _.isFunction(service.collection) ? service.collection.apply(service, [params, query, body, cookies]) : service.collection,
-                template = _.isFunction(service.template) ? service.template.apply(service, [params, query, body, cookies]) : service.template,
+                template = service.template,
                 promise;
 
             if(!isCollection) {
@@ -74,6 +74,7 @@ var generate = function(req, res, next) {
 var setValues = function(template, params, scope) {
 
     template = template || null;
+    template = _.isFunction(template) ? template.apply(this, params) : template;
 
     return when.promise(function(resolve, reject, notify) {
 


### PR DESCRIPTION
I don't know if `template` function called just one time is by design, but in my use case I would like to call `template` function on each iteration:

```
var faker = require('faker');

var currentId = 0;

var userList = {
	path: '/user',
	collection: true,
	template: function() {

		currentId += 1;

		var firstName = faker.name.firstName();
		var lastName = faker.name.lastName();

		var username = faker.internet.userName(firstName, lastName);
		var password = faker.internet.password();

		return {
			id: currentId,
			username: username,
			firstName: firstName,
			lastName: lastName,
			password: password
		};
	}
};

module.exports = [userList];
```

With my PR call to /user makes this:

```
[{"id":1,"username":"Angel.Greenholt","firstName":"Angel","lastName":"Greenholt","password":"ECF7D0e6i2CjKyt"},
{"id":2,"username":"Dexter_OConner87","firstName":"Dexter","lastName":"O'Conner","password":"Mkfv0_WIVgWkuTs"},
{"id":3,"username":"Paxton_Cormier85","firstName":"Paxton","lastName":"Cormier","password":"EnJjvxcNFrsAq53"}]
```